### PR TITLE
added the `case` keyword before the full pattern for scalac 3.3

### DIFF
--- a/simplesql/src/simplesql.scala
+++ b/simplesql/src/simplesql.scala
@@ -72,7 +72,7 @@ object Query {
     val args: Seq[Expr[_]] = args0 match {
       case Varargs(exprs) => exprs
     }
-    val writers: Seq[Expr[SimpleWriter[_]]] = for ('{ $arg: t } <- args) yield {
+    val writers: Seq[Expr[SimpleWriter[_]]] = for (case '{ $arg: t } <- args) yield {
       val w = TypeRepr.of[SimpleWriter].appliedTo(
         TypeRepr.of[t].widen
       )


### PR DESCRIPTION
fixed with: scalac -rewrite -source 3.2-migration simplesql.scala.  The warning were:
warn] ./simplesql.scala:75:52
[warn] pattern's type scala.quoted.Expr[t] is more specialized than the right hand side expression's type quoted.Expr[?] [warn] 
[warn] If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern, [warn] which will result in a filtering for expression (using `withFilter`). [warn] This patch can be rewritten automatically under -rewrite -source 3.2-migration.
[warn]     val writers: Seq[Expr[SimpleWriter[_]]] = for ('{ $arg: t } <- args) yield {
[warn]                                                    ^^^^^^^^^^^^